### PR TITLE
Add unit tests for flags -i, -I, and -g used together

### DIFF
--- a/t/ack-g.t
+++ b/t/ack-g.t
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 18;
+use Test::More tests => 20;
 
 use lib 't';
 use Util;
@@ -127,7 +127,6 @@ subtest 'Case-insensitive via -i' => sub {
     ack_sets_match( [ @args, @files ], \@expected, "Looking for -i -g $regex " );
 };
 
-
 subtest 'Case-insensitive via (?i:)' => sub {
     plan tests => 1;
 
@@ -142,6 +141,32 @@ subtest 'Case-insensitive via (?i:)' => sub {
     ack_sets_match( [ @args, @files ], \@expected, "Looking for $regex" );
 };
 
+subtest 'Negate -i via -I' => sub {
+    plan tests => 1;
+
+    my @expected = qw();
+    my $regex = 'PIPE';
+
+    my @args = ( '-i', '-I', '-g', $regex);
+    my @files = qw( t/swamp );
+
+    ack_sets_match( [ @args, @files ], \@expected, "Looking for -i -I -g $regex" );
+};
+
+subtest 'Negate -I via -i' => sub {
+    plan tests => 1;
+
+    my @expected = qw(
+        t/swamp/pipe-stress-freaks.F
+    );
+    my $regex = 'PIPE';
+
+    my @args  = ( '-I', '-i', '-g', $regex );
+    my @files = qw( t/swamp );
+
+    ack_sets_match( [ @args, @files ], \@expected, "Looking for -I -i -g $regex " );
+
+};
 
 subtest 'File on command line is always searched' => sub {
     plan tests => 1;

--- a/t/ack-g.t
+++ b/t/ack-g.t
@@ -127,6 +127,7 @@ subtest 'Case-insensitive via -i' => sub {
     ack_sets_match( [ @args, @files ], \@expected, "Looking for -i -g $regex " );
 };
 
+
 subtest 'Case-insensitive via (?i:)' => sub {
     plan tests => 1;
 
@@ -141,6 +142,7 @@ subtest 'Case-insensitive via (?i:)' => sub {
     ack_sets_match( [ @args, @files ], \@expected, "Looking for $regex" );
 };
 
+
 subtest 'Negate -i via -I' => sub {
     plan tests => 1;
 
@@ -152,6 +154,7 @@ subtest 'Negate -i via -I' => sub {
 
     ack_sets_match( [ @args, @files ], \@expected, "Looking for -i -I -g $regex" );
 };
+
 
 subtest 'Negate -I via -i' => sub {
     plan tests => 1;
@@ -167,6 +170,7 @@ subtest 'Negate -I via -i' => sub {
     ack_sets_match( [ @args, @files ], \@expected, "Looking for -I -i -g $regex " );
 
 };
+
 
 subtest 'File on command line is always searched' => sub {
     plan tests => 1;


### PR DESCRIPTION
Resolve #196 

Decided to place this in `ack-g.t` since it already had tests for `-g` and `-i` used together.