### PR TITLE
Fix error in output when `-x` is used with `-s`

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -88,6 +88,17 @@ will remove them later.
 We have a perlcriticrc and a perltidyrc file for checking the Perl source
 files.
 
+## Docker for Development
+
+To simplify setup of a development environment for working on ack, you
+can use the provided Docker-based environment. Running `docker-compose build`
+will generate an isolated development environment that has Perl 5.30 and
+the required `File::Next` package installed. To get a bash shell in the
+development environment by running `docker-compose run app bash`. The first
+time this runs it will run `perl Makefile.PL` to generate the `Makefile` and
+then run `make` followed by `make test`. Subsequent runs of
+`docker-compose run app bash` will not repeat that process.
+
 ## How to cut a release
 
 ### For all releases

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM perl:5.30
+
+RUN mkdir -p /app
+WORKDIR /app
+
+RUN perl -MCPAN -e "install File::Next"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,3 +4,4 @@ RUN mkdir -p /app
 WORKDIR /app
 
 RUN perl -MCPAN -e "install File::Next"
+RUN perl -MCPAN -e "install Test::Pod"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+version: '2.0'
+services:
+  app:
+    build: .
+    volumes:
+      - .:/app
+    entrypoint: /app/docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+if [ ! -f Makefile ]
+then
+  perl Makefile.PL
+  make
+  make test
+fi
+
+exec "$@"

--- a/lib/App/Ack/Files.pm
+++ b/lib/App/Ack/Files.pm
@@ -67,10 +67,15 @@ sub from_file {
     my $file  = shift;
 
     my $error_handler = _generate_error_handler();
+    my $warning_handler = $error_handler;
+    if ( !$App::Ack::report_bad_filenames ) {
+      $warning_handler = sub {};
+    }
+
     my $iter =
         File::Next::from_file( {
             error_handler   => $error_handler,
-            warning_handler => $error_handler,
+            warning_handler => $warning_handler,
             sort_files      => $opt->{sort_files},
         }, $file ) or return undef;
 

--- a/t/ack-x.t
+++ b/t/ack-x.t
@@ -3,7 +3,7 @@
 use strict;
 use warnings;
 
-use Test::More tests => 2;
+use Test::More tests => 3;
 
 use lib 't';
 use Util;
@@ -52,6 +52,25 @@ else {
 
 sets_match( $stdout, \@expected, __FILE__ );
 is_empty_array( $stderr );
+
+
+# GH #175: -s doesn't work with -x
+subtest 'GH #175' => sub {
+    plan tests => 5;
+
+    my $file = create_tempfile( 'non-existent-filename.txt' );
+
+    # Without -s, we get an error about the missing file.
+    my ($stdout,$stderr) = pipe_into_ack_with_stderr( $file->filename, '-x', 'foo' );
+    is_empty_array( $stdout, 'Nothing matches' );
+    is( scalar @{$stderr}, 1, 'Only one line of error' );
+    like( $stderr->[0], qr/\Qnon-existent-filename.txt: No such file/, 'Proper error message' );
+
+    # With -s, there is no warning.
+    ($stdout,$stderr) = pipe_into_ack_with_stderr( $file->filename, '-x', '-s', 'foo' );
+    is_empty_array( $stdout, 'Nothing matches' );
+    is_empty_array( $stderr, 'No errors' );
+};
 
 done_testing();
 exit 0;

--- a/xt/coresubs.t
+++ b/xt/coresubs.t
@@ -42,7 +42,7 @@ for my $word ( qw( chdir mkdir ) ) {
     subtest "Finding $word" => sub {
         plan tests => 3;
 
-        my @args = ( '-w', '--ignore-file=is:coresubs.t', '--ignore-dir=garage', @exclusions, $word );
+        my @args = ( '-w', '--ignore-file=is:coresubs.t', '--ignore-file=is:Dockerfile', '--ignore-dir=garage', @exclusions, $word );
         my @results = run_ack( @args );
 
         is( scalar @results, 1, 'Exactly one hit...' ) or do { require Data::Dumper; warn Data::Dumper::Dumper( \@results ) };


### PR DESCRIPTION
Attempts to fix issue #175. Suppress file missing output when `-x` is used in combination with `-s`.

Includes commits from pull request #208, but those can be removed via rebase if needed.
