### PR TITLE
Fix '-s option has no effect when -x option is used' bug

### DIFF
--- a/lib/App/Ack/Files.pm
+++ b/lib/App/Ack/Files.pm
@@ -125,15 +125,7 @@ sub _generate_error_handler {
             App::Ack::warn( $msg );
         };
     }
-    else {
-        return sub {
-            my $msg = shift;
-            if ( $! == EACCES ) {
-                return;
-            }
-            App::Ack::warn( $msg );
-        };
-    }
+    return sub {};
 }
 
 1;

--- a/t/ack-g.t
+++ b/t/ack-g.t
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 18;
+use Test::More tests => 20;
 
 use lib 't';
 use Util;
@@ -127,7 +127,6 @@ subtest 'Case-insensitive via -i' => sub {
     ack_sets_match( [ @args, @files ], \@expected, "Looking for -i -g $regex " );
 };
 
-
 subtest 'Case-insensitive via (?i:)' => sub {
     plan tests => 1;
 
@@ -142,6 +141,32 @@ subtest 'Case-insensitive via (?i:)' => sub {
     ack_sets_match( [ @args, @files ], \@expected, "Looking for $regex" );
 };
 
+subtest 'Negate -i via -I' => sub {
+    plan tests => 1;
+
+    my @expected = qw();
+    my $regex = 'PIPE';
+
+    my @args = ( '-i', '-I', '-g', $regex);
+    my @files = qw( t/swamp );
+
+    ack_sets_match( [ @args, @files ], \@expected, "Looking for -i -I -g $regex" );
+};
+
+subtest 'Negate -I via -i' => sub {
+    plan tests => 1;
+
+    my @expected = qw(
+        t/swamp/pipe-stress-freaks.F
+    );
+    my $regex = 'PIPE';
+
+    my @args  = ( '-I', '-i', '-g', $regex );
+    my @files = qw( t/swamp );
+
+    ack_sets_match( [ @args, @files ], \@expected, "Looking for -I -i -g $regex " );
+
+};
 
 subtest 'File on command line is always searched' => sub {
     plan tests => 1;

--- a/t/ack-g.t
+++ b/t/ack-g.t
@@ -127,6 +127,7 @@ subtest 'Case-insensitive via -i' => sub {
     ack_sets_match( [ @args, @files ], \@expected, "Looking for -i -g $regex " );
 };
 
+
 subtest 'Case-insensitive via (?i:)' => sub {
     plan tests => 1;
 
@@ -141,6 +142,7 @@ subtest 'Case-insensitive via (?i:)' => sub {
     ack_sets_match( [ @args, @files ], \@expected, "Looking for $regex" );
 };
 
+
 subtest 'Negate -i via -I' => sub {
     plan tests => 1;
 
@@ -152,6 +154,7 @@ subtest 'Negate -i via -I' => sub {
 
     ack_sets_match( [ @args, @files ], \@expected, "Looking for -i -I -g $regex" );
 };
+
 
 subtest 'Negate -I via -i' => sub {
     plan tests => 1;
@@ -167,6 +170,7 @@ subtest 'Negate -I via -i' => sub {
     ack_sets_match( [ @args, @files ], \@expected, "Looking for -I -i -g $regex " );
 
 };
+
 
 subtest 'File on command line is always searched' => sub {
     plan tests => 1;


### PR DESCRIPTION
Resolves  #175

New behavior:
```
$ echo foo | ack -x bar
ack: foo: No such file
$ echo foo | ack -x -s bar
```

grep behavior for comparison:
```
$ echo foo | xargs grep bar
grep: foo: No such file or directory
$ echo foo | xargs grep -s bar
```

I believe the fact that the error message does not contain the "or directoy" comes from [File::Next](https://github.com/petdance/file-next/blob/dev/Next.pm#L363).

Tried writing unit tests for this but got kind of confused when trying to implement it like in [ack-x.t](https://github.com/beyondgrep/ack3/blob/dev/t/ack-x.t) and didn't quite get it to work. Any assistance would be appreciated.