### PR TITLE
Fix typo in manpage section on file types

### DIFF
--- a/ack
+++ b/ack
@@ -1692,7 +1692,7 @@ also be specified as B<--perl>, although this is deprecated.
 
 Type inclusions can be repeated and are ORed together.
 
-See I<ack --help=types> for a list of valid types.
+See I<ack --help-types> for a list of valid types.
 
 =item B<-T TYPE>, B<--type=noTYPE>, B<--noTYPE>
 


### PR DESCRIPTION
I encountered a typo in the manpage; hopefully this saves somebody else 5 minutes of searching around for the correct command-line flag.