### PR TITLE
Add filename coloring with '--count/-c'

### DIFF
--- a/ack
+++ b/ack
@@ -324,7 +324,11 @@ sub file_loop_c {
 
         if ( !$opt_l || $matches_for_this_file > 0 ) {
             if ( $opt_show_filename ) {
-                App::Ack::say( $file->name, ':', $matches_for_this_file );
+                my $display_filename = $file->name;
+                if ( $opt_color ) {
+                    $display_filename = Term::ANSIColor::colored($display_filename, $ENV{ACK_COLOR_FILENAME});
+                }
+                App::Ack::say( $display_filename, ':', $matches_for_this_file );
             }
             else {
                 App::Ack::say( $matches_for_this_file );

--- a/t/ack-color.t
+++ b/t/ack-color.t
@@ -8,7 +8,7 @@ use Test::More;
 use lib 't';
 use Util;
 
-plan tests => 14;
+plan tests => 15;
 
 prep_environment();
 
@@ -131,7 +131,23 @@ subtest 'Passing args for colors' => sub {
         "${red}$file${color_end}",
         "${bold_white_on_green}11${color_end}:${blue_bold}22${color_end}:Look on my works, ye ${cyan_on_red}Mighty${color_end}, and despair!'$line_end",
     ] );
+};
 
+subtest 'Filename colors with count' => sub {
+    plan tests => 2;
+
+    my $file = reslash( 't/text/bill-of-rights.txt' );
+    my $expected = "${red}$file${color_end}:1";
+    my @args = qw(
+        Congress
+        --count
+        --with-filename
+        --color
+        --color-filename=red
+    );
+
+    my @results = run_ack( @args, $file );
+    is_deeply( \@results, [ $expected ], "Filename colored when called with '--color'" );
 };
 
 

--- a/t/ack-color.t
+++ b/t/ack-color.t
@@ -134,20 +134,33 @@ subtest 'Passing args for colors' => sub {
 };
 
 subtest 'Filename colors with count' => sub {
-    plan tests => 2;
+    plan tests => 5;
 
-    my $file = reslash( 't/text/bill-of-rights.txt' );
-    my $expected = "${red}$file${color_end}:1";
-    my @args = qw(
+    my $file                   = reslash('t/text/bill-of-rights.txt');
+    my $expected_with_color    = "${red}$file${color_end}:1";
+    my $expected_without_color = "$file:1";
+    my @args                   = qw(
         Congress
         --count
         --with-filename
-        --color
         --color-filename=red
     );
 
-    my @results = run_ack( @args, $file );
-    is_deeply( \@results, [ $expected ], "Filename colored when called with '--color'" );
+    my @interactive_results = run_ack_interactive( @args, $file );
+    is_deeply( \@interactive_results, [$expected_with_color], "Filename colored when run interactively" );
+
+    my @non_interactive_colorless_results = run_ack( @args, $file );
+    is_deeply(
+        \@non_interactive_colorless_results,
+        [$expected_without_color], "Filename not colored when output is redirected",
+    );
+
+    my @args_with_color                 = ( @args, "--color" );
+    my @non_interactive_colored_results = run_ack( @args_with_color, $file );
+    is_deeply(
+        \@non_interactive_colored_results,
+        [$expected_with_color], "Filename colored when output is redirected and '--color' is used",
+    );
 };
 
 


### PR DESCRIPTION
This colors the filename in the output if the output is not redirected
or '--color' is used.

This addresses Issue #282