### PR TITLE
Fix capitalization

### DIFF
--- a/Changes
+++ b/Changes
@@ -241,7 +241,7 @@ Add -p as a shorter version of --proximate.
 Added -P as a negation of --proximate.  It is the same as --proximate=0.
 If you have --proximate in an .ackrc, -P can be used to cancel it.
 
-Added --ts for Typescript.
+Added --ts for TypeScript.
 
 
 2.999_03 Fri Jan 19 11:02:46 CST 2018

--- a/ack
+++ b/ack
@@ -2163,7 +2163,7 @@ Options are then loaded from the command line.
 ack is based at GitHub at L<https://github.com/beyondgrep/ack3>
 
 Please report any bugs or feature requests to the issues list at
-Github: L<https://github.com/beyondgrep/ack3/issues>.
+GitHub: L<https://github.com/beyondgrep/ack3/issues>.
 
 Please include the operating system that you're using; the output of
 the command C<ack --version>; and any customizations in your F<.ackrc>
@@ -2190,7 +2190,7 @@ L<https://beyondgrep.com/>
 
 L<https://github.com/beyondgrep/ack3>
 
-=item * The ack issues list at Github
+=item * The ack issues list at GitHub
 
 L<https://github.com/beyondgrep/ack3/issues>
 

--- a/lib/App/Ack/ConfigDefault.pm
+++ b/lib/App/Ack/ConfigDefault.pm
@@ -152,7 +152,7 @@ sub _options_block {
 # core dumps
 --ignore-file=match:/core[.]\d+$/
 
-# minified Javascript
+# minified JavaScript
 --ignore-file=match:/[.-]min[.]js$/
 --ignore-file=match:/[.]js[.]min$/
 
@@ -456,7 +456,7 @@ sub _options_block {
 # https://toml.io/
 --type-add=toml:ext:toml
 
-# Typescript
+# TypeScript
 # https://www.typescriptlang.org/
 --type-add=ts:ext:ts,tsx
 


### PR DESCRIPTION
A couple of minor capitalization fixes (`Github` -> `GitHub`, `Javascript` -> `JavaScript` etc)