### PR TITLE
Add sbt file extension

### DIFF
--- a/lib/App/Ack/ConfigDefault.pm
+++ b/lib/App/Ack/ConfigDefault.pm
@@ -405,7 +405,7 @@ sub _options_block {
 
 # Scala
 # https://www.scala-lang.org/
---type-add=scala:ext:scala
+--type-add=scala:ext:scala,sbt
 
 # Scheme
 # https://groups.csail.mit.edu/mac/projects/scheme/


### PR DESCRIPTION
Add "*.sbt" file extension to list of scala language extensions. SBT (https://www.scala-sbt.org/) is the most popular tool used by Scala developers to build projects. Project files has extension "*.sbt", but they are valid Scala files. This is exactly the same as with already supported by ack extension "*.gradle" which are valid Groovy files.