### PR TITLE
Don't Color `--output='$f'`

### DIFF
--- a/ack
+++ b/ack
@@ -905,20 +905,23 @@ sub print_line_with_options {
     my @line_parts;
 
     if ( $opt_show_filename && defined($filename) ) {
-        my $colno;
-        $colno = get_match_colno() if $opt_column;
+        # Because you can't "local"-ize lexical variables...
+        my ( $_filename, $_lineno ) = ( $filename, $lineno );
+
+        my $_colno;
+        $_colno = get_match_colno() if $opt_column;
         if ( $opt_color ) {
-            $filename = Term::ANSIColor::colored( $filename, $ENV{ACK_COLOR_FILENAME} );
-            $lineno   = Term::ANSIColor::colored( $lineno,   $ENV{ACK_COLOR_LINENO} );
-            $colno    = Term::ANSIColor::colored( $colno,    $ENV{ACK_COLOR_COLNO} ) if $opt_column;
+            $_filename = Term::ANSIColor::colored( $_filename, $ENV{ACK_COLOR_FILENAME} );
+            $_lineno   = Term::ANSIColor::colored( $_lineno,   $ENV{ACK_COLOR_LINENO} );
+            $_colno    = Term::ANSIColor::colored( $_colno,    $ENV{ACK_COLOR_COLNO} ) if $opt_column;
         }
         if ( $opt_heading ) {
-            push @line_parts, $lineno;
+            push @line_parts, $_lineno;
         }
         else {
-            push @line_parts, $filename, $lineno;
+            push @line_parts, $_filename, $_lineno;
         }
-        push @line_parts, $colno if $opt_column;
+        push @line_parts, $_colno if $opt_column;
     }
 
     if ( $opt_output ) {

--- a/t/ack-output-color.t
+++ b/t/ack-output-color.t
@@ -3,12 +3,19 @@
 use warnings;
 use strict;
 
-use Test::More tests => 50;
+use Test::More tests => 26;
+use Term::ANSIColor qw(color);
 
 use lib 't';
 use Util;
 
 prep_environment();
+
+my $CFN      = color 'bold green';
+my $CRESET   = color 'reset';
+my $CLN      = color 'bold yellow';
+my $CM       = color 'black on_yellow';
+my $LINE_END = "\e[0m\e[K";
 
 DOLLAR_1: {
     my @files = qw( t/text/ );
@@ -34,7 +41,7 @@ HERE
 
     my @files = qw( t/text/gettysburg.txt );
     my @args = qw( free --output=$_x$_ );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Matching line' );
 }
@@ -42,17 +49,20 @@ HERE
 
 ARG_MULTIPLE_FILES: {
     # Note the first line is there twice because it matches twice.
+    # Blank lines are a result of '--break' being enabled by default
     my @expected = line_split( <<'HERE' );
 or prohibiting the free exercise thereof; or abridging the freedom of
 or prohibiting the free exercise thereof; or abridging the freedom of
 A well regulated Militia, being necessary to the security of a free State,
+
 Number of free Persons, including those bound to Service for a Term
+
 shall have a new birth of freedom -- and that government of the people,
 HERE
 
     my @files = qw( t/text );
     my @args = qw( free --sort-files -h --output=$_ );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Matching line' );
 }
@@ -87,23 +97,28 @@ MATCH: {
 
     my @files = qw( t/text/gettysburg.txt );
     my @args = qw( free --output=$& );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Part of a line matching pattern' );
 }
 
 MATCH_MULTIPLE_FILES: {
-    my @expected = line_split( <<'HERE' );
-t/text/bill-of-rights.txt:4:free
-t/text/bill-of-rights.txt:4:free
-t/text/bill-of-rights.txt:10:free
-t/text/constitution.txt:32:free
-t/text/gettysburg.txt:23:free
+    my @expected = line_split( <<"HERE" );
+${CFN}t/text/bill-of-rights.txt${CRESET}
+${CLN}4${CRESET}:free
+${CLN}4${CRESET}:free
+${CLN}10${CRESET}:free
+
+${CFN}t/text/constitution.txt${CRESET}
+${CLN}32${CRESET}:free
+
+${CFN}t/text/gettysburg.txt${CRESET}
+${CLN}23${CRESET}:free
 HERE
 
     my @files = qw ( t/text );
     my @args = qw( free --sort-files --output=$& );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Part of a line matching pattern' );
 }
@@ -116,7 +131,7 @@ PREMATCH: {
 
     my @files = qw( t/text/gettysburg.txt );
     my @args = qw( freedom --output=$` );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Part of a line preceding match' );
 }
@@ -125,12 +140,13 @@ PREMATCH_MULTIPLE_FILES: {
     # No HEREDOC here since we do not want our editor/IDE messing with trailing whitespace.
     my @expected = (
         'or prohibiting the free exercise thereof; or abridging the ',
+        '',
         'shall have a new birth of '
     );
 
     my @files = qw( t/text/);
     my @args = qw( freedom -h --sort-files --output=$` );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Part of a line preceding match' );
 }
@@ -142,7 +158,7 @@ HERE
 
     my @files = qw( t/text/gettysburg.txt );
     my @args = qw( freedom --output=$' );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Part of a line that follows match' );
 }
@@ -150,12 +166,13 @@ HERE
 POSTMATCH_MULTIPLE_FILES: {
     my @expected = line_split( <<'HERE' );
  of
+
  -- and that government of the people,
 HERE
 
     my @files = qw( t/text/ );
     my @args = qw( freedom -h --sort-files --output=$' );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Part of a line that follows match' );
 }
@@ -167,7 +184,7 @@ SUBPATTERN_MATCH: {
 
     my @files = qw( t/text/amontillado.txt );
     my @args = qw( (love).+(God).+(Montresor) --output=$1-$2-$3 );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Capturing parentheses match' );
 }
@@ -176,12 +193,13 @@ SUBPATTERN_MATCH_MULTIPLE_FILES: {
     my @expected = line_split( <<'HERE' );
 the-free-exercise
 a-free-State
+
 of-free-Persons
 HERE
 
     my @files = qw( t/text/ );
     my @args = qw( (\w+)\s(free)\s(\w+) -h --sort-files --output=$1-$2-$3 );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Capturing parentheses match' );
 }
@@ -193,82 +211,99 @@ INPUT_LINE_NUMBER: {
 
     my @files = qw( t/text/bill-of-rights.txt );
     my @args = qw( quartered --output=line:$. );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Line number' );
 }
 
 INPUT_LINE_NUMBER_MULTIPLE_FILES: {
-    my @expected = line_split( <<'HERE' );
-t/text/bill-of-rights.txt:4:line:4
-t/text/bill-of-rights.txt:4:line:4
-t/text/bill-of-rights.txt:10:line:10
-t/text/constitution.txt:32:line:32
-t/text/gettysburg.txt:23:line:23
+    my @expected = line_split( <<"HERE" );
+${CFN}t/text/bill-of-rights.txt${CRESET}
+${CLN}4${CRESET}:line:4
+${CLN}4${CRESET}:line:4
+${CLN}10${CRESET}:line:10
+
+${CFN}t/text/constitution.txt${CRESET}
+${CLN}32${CRESET}:line:32
+
+${CFN}t/text/gettysburg.txt${CRESET}
+${CLN}23${CRESET}:line:23
 HERE
 
     my @files = qw( t/text/ );
     my @args = qw( free --sort-files --output=line:$. );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Line number' );
 }
 
 LAST_PAREN_MATCH: {
-    my @expected = line_split( <<'HERE' );
-t/text/amontillado.txt:124:love
-t/text/amontillado.txt:309:love
-t/text/amontillado.txt:311:love
-t/text/constitution.txt:267:hate
+    my @expected = line_split( <<"HERE" );
+${CFN}t/text/amontillado.txt${CRESET}
+${CLN}124${CRESET}:love
+${CLN}309${CRESET}:love
+${CLN}311${CRESET}:love
+
+${CFN}t/text/constitution.txt${CRESET}
+${CLN}267${CRESET}:hate
 HERE
 
     my @files = qw( t/text/ );
     my @args = qw( (love)|(hate) --sort-files --output=$+ );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Last paren match' );
 }
 
 
 COMBOS_1: {
-    my @expected = line_split( <<'HERE' );
-t/text/amontillado.txt:124:love-124-d; you are happy,
-t/text/amontillado.txt:309:love-309- of God, Montresor!"
-t/text/amontillado.txt:311:love-311- of God!"
-t/text/constitution.txt:267:hate-267-ver, from any King, Prince, or foreign State.
+    my @expected = line_split( <<"HERE" );
+${CFN}t/text/amontillado.txt${CRESET}
+${CLN}124${CRESET}:love-124-d; you are happy,
+${CLN}309${CRESET}:love-309- of God, Montresor!"
+${CLN}311${CRESET}:love-311- of God!"
+
+${CFN}t/text/constitution.txt${CRESET}
+${CLN}267${CRESET}:hate-267-ver, from any King, Prince, or foreign State.
 HERE
 
     my @files = qw( t/text/ );
     my @args = qw( (love)|(hate) --sort-files --output=$+-$.-$' );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Combos 1' );
 }
 
 
 COMBOS_2: {
-    my @expected = line_split( <<'HERE' );
-t/text/amontillado.txt:124:happy-happy-happy
-t/text/raven.txt:73:happy-happy-happy
+    my @expected = line_split( <<"HERE" );
+${CFN}t/text/amontillado.txt${CRESET}
+${CLN}124${CRESET}:happy-happy-happy
+
+${CFN}t/text/raven.txt${CRESET}
+${CLN}73${CRESET}:happy-happy-happy
 HERE
 
     my @files = qw( t/text/ );
     my @args = qw( (happy) --sort-files -i --output=$1-$&-$1 );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Combos 2' );
 }
 
 
 COMBOS_3: {
-    my @expected = line_split( <<'HERE' );
-t/text/amontillado.txt:124:precious. You are rich, respected, admired, beloved; you are ---,--happy
-t/text/raven.txt:73:Caught from some un--- master whom unmerciful Disaster--happy
+    my @expected = line_split( <<"HERE" );
+${CFN}t/text/amontillado.txt${CRESET}
+${CLN}124${CRESET}:precious. You are rich, respected, admired, beloved; you are ---,--happy
+
+${CFN}t/text/raven.txt${CRESET}
+${CLN}73${CRESET}:Caught from some un--- master whom unmerciful Disaster--happy
 HERE
 
     my @files = qw( t/text/ );
     my @args = qw( (happy) --sort-files -i --output=$`---$'--$+ );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Combos 2' );
 }
@@ -276,13 +311,14 @@ HERE
 
 NUMERIC_SUBSTITUTIONS: {
     # Make sure that substitutions don't affect future substitutions.
-    my @expected = line_split( <<'HERE' );
-t/text/constitution.txt:269:Section 10 on line 269
+    my @expected = line_split( <<"HERE" );
+${CFN}t/text/constitution.txt${CRESET}
+${CLN}269${CRESET}:Section 10 on line 269
 HERE
 
     my @files = qw( t/text/bill-of-rights.txt t/text/constitution.txt );
     my @args = ( '(\d\d)', '--output=Section $1 on line $.' );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Numeric substitutions' );
 }
@@ -291,13 +327,14 @@ HERE
 CHARACTER_SUBSTITUTIONS: {
     # Make sure that substitutions don't affect future substitutions.
     my @expected = line_split( <<"HERE" );
-t/text/bill-of-rights.txt:15:No Soldier shall, in time of peace be
+${CFN}t/text/bill-of-rights.txt${CRESET}
+${CLN}15${CRESET}:No Soldier shall, in time of peace be
 in any house, without\tin any house, without
 HERE
 
     my @files = qw( t/text/ );
     my @args = ( '\s+quartered\s+(.+)', '--output=$`\n$1\t$1' );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Character substitutions' );
 }
@@ -311,7 +348,7 @@ HERE
 
     my @files = qw( t/text/ozymandias.txt );
     my @args = qw( visage --output=$f:$.:$_ );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Filename with matching line' );
 }
@@ -324,7 +361,7 @@ HERE
 
     my @files = qw( t/text/ozymandias.txt );
     my @args = qw( visage --output=$f:$.:$& );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Filename with match' );
 }
@@ -337,24 +374,29 @@ HERE
 
     my @files = qw( t/text/ozymandias.txt );
     my @args = qw( (visage) --output=$f:$.:$+ );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Filename with last match' );
 }
 
 FILENAME_SUBSTITUTION_MULTIPLE : {
-    my @expected = line_split( <<'HERE' );
-t/text/amontillado.txt:3:t/text/amontillado.txt:3:The thousand injuries of Fortunato I had borne as I best could; but
-t/text/constitution.txt:38:t/text/constitution.txt:38:thirty Thousand, but each State shall have at Least one Representative;
-t/text/constitution.txt:241:t/text/constitution.txt:241:Congress prior to the Year one thousand eight hundred and eight, but
-t/text/constitution.txt:501:t/text/constitution.txt:501:which may be made prior to the Year One thousand eight hundred and eight
-t/text/ozymandias.txt:3:t/text/ozymandias.txt:3:Stand in the desert... Near them, on the sand,
-t/text/ozymandias.txt:14:t/text/ozymandias.txt:14:The lone and level sands stretch far away.
+    my @expected = line_split( <<"HERE" );
+${CFN}t/text/amontillado.txt${CRESET}
+${CLN}3${CRESET}:t/text/amontillado.txt:3:The thousand injuries of Fortunato I had borne as I best could; but
+
+${CFN}t/text/constitution.txt${CRESET}
+${CLN}38${CRESET}:t/text/constitution.txt:38:thirty Thousand, but each State shall have at Least one Representative;
+${CLN}241${CRESET}:t/text/constitution.txt:241:Congress prior to the Year one thousand eight hundred and eight, but
+${CLN}501${CRESET}:t/text/constitution.txt:501:which may be made prior to the Year One thousand eight hundred and eight
+
+${CFN}t/text/ozymandias.txt${CRESET}
+${CLN}3${CRESET}:t/text/ozymandias.txt:3:Stand in the desert... Near them, on the sand,
+${CLN}14${CRESET}:t/text/ozymandias.txt:14:The lone and level sands stretch far away.
 HERE
 
     my @files = qw( t/text );
     my @args = qw( sand --output=$f:$.:$_ );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Multiple files with matching line' );
 }
@@ -368,24 +410,29 @@ HERE
 
     my @files = qw( t/text/ozymandias.txt );
     my @args = qw( sand --output=literal );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
-    lists_match( \@results, \@expected, 'Single file with literal replacement' );
+    lists_match( \@results, \@expected, 'Filename with last match' );
 }
 
 LITERAL_MULTIPLE_FILES : {
-    my @expected = line_split( <<'HERE' );
-t/text/amontillado.txt:3:literal
-t/text/constitution.txt:38:literal
-t/text/constitution.txt:241:literal
-t/text/constitution.txt:501:literal
-t/text/ozymandias.txt:3:literal
-t/text/ozymandias.txt:14:literal
+    my @expected = line_split( <<"HERE" );
+${CFN}t/text/amontillado.txt${CRESET}
+${CLN}3${CRESET}:literal
+
+${CFN}t/text/constitution.txt${CRESET}
+${CLN}38${CRESET}:literal
+${CLN}241${CRESET}:literal
+${CLN}501${CRESET}:literal
+
+${CFN}t/text/ozymandias.txt${CRESET}
+${CLN}3${CRESET}:literal
+${CLN}14${CRESET}:literal
 HERE
 
     my @files = qw( t/text );
     my @args = qw( sand --output=literal );
-    my @results = run_ack( @args, @files );
+    my @results = run_ack_interactive( @args, @files );
 
     lists_match( \@results, \@expected, 'Multiple files with literal replacement' );
 }


### PR DESCRIPTION
The following seems inconsistent:

```
ack ^root: --output='Matched line $. of file $f' /etc/passwd /dev/null
/etc/passwd       <-- green
12:Matched line 12 of file /etc/passwd
^^              ^^         ^^^^^^^^^^^
yellow          white      green
```

This PR makes it so only the "metadata" is colored, not the actual `--output`

[NOTE: This came up while I was working on my forthcoming PR, which will add a `--no-lineno` option...]