### PR TITLE
Fix inclusion of excluded file types

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -69,6 +69,7 @@ t/ack-s.yaml
 t/ack-show-types.t
 t/ack-type-del.t
 t/ack-type.t
+t/ack-type.yaml
 t/ack-v.yaml
 t/ack-version.t
 t/ack-w.t

--- a/lib/App/Ack/ConfigLoader.pm
+++ b/lib/App/Ack/ConfigLoader.pm
@@ -176,6 +176,9 @@ sub _process_filetypes {
             if ( not $value ) {
                 @filters = map { $_->invert() } @filters;
             }
+            else {
+                _uninvert_filter( $opt, @filters );
+            }
 
             push @{ $opt->{'filters'} }, @filters;
         };

--- a/lib/App/Ack/ConfigLoader.pm
+++ b/lib/App/Ack/ConfigLoader.pm
@@ -124,8 +124,9 @@ sub _uninvert_filter {
     for ( my $i = 0; $i < @{ $opt->{filters} }; $i++ ) {
         my $opt_filter = @{ $opt->{filters} }[$i];
 
-        # XXX Do a real list comparison? This just checks string equivalence.
-        if ( $opt_filter->is_inverted() && "$opt_filter->{filter}" eq "@filters" ) {
+        if ( $opt_filter->is_inverted()
+            && grep { $_ == $opt_filter->{filter} } @filters )
+        {
             splice @{ $opt->{filters} }, $i, 1;
             $i--;
         }

--- a/t/ack-type.yaml
+++ b/t/ack-type.yaml
@@ -1,0 +1,20 @@
+---
+name: --type-set and exclude
+args: >-
+  --ignore-ack-defaults
+  --type-set=cmake:is:CMakeLists.txt
+  --type=nocmake
+  -k -f t/swamp
+exitcode: 1
+stderr: ''
+stdout: ''
+
+---
+name: --type-set and override exclusion
+args: >-
+  --ignore-ack-defaults
+  --type-set=cmake:is:CMakeLists.txt
+  --type=nocmake
+  -t cmake -f t/swamp
+stdout: |
+  t/swamp/CMakeLists.txt

--- a/t/ack-type.yaml
+++ b/t/ack-type.yaml
@@ -18,3 +18,27 @@ args: >-
   -t cmake -f t/swamp
 stdout: |
   t/swamp/CMakeLists.txt
+
+---
+name: --type-set, --type-add, and exclude
+args: >-
+  --ignore-ack-defaults
+  --type-set=cmake:is:CMakeLists.txt
+  --type-add=cmake:ext:cmake
+  --type=nocmake
+  -k -f t/swamp
+exitcode: 1
+stderr: ''
+stdout: ''
+
+---
+name: --type-set, --type-add, and override exclusion
+args: >-
+  --ignore-ack-defaults
+  --type-set=cmake:is:CMakeLists.txt
+  --type-add=cmake:ext:cmake
+  --type=nocmake
+  -t cmake -f t/swamp
+stdout: |
+  t/swamp/CMakeLists.txt
+  t/swamp/stuff.cmake

--- a/t/yaml.t
+++ b/t/yaml.t
@@ -3,7 +3,7 @@
 use warnings;
 use strict;
 
-use Test::More tests => 26;
+use Test::More tests => 27;
 
 use lib 't';
 use Util;


### PR DESCRIPTION
It may be convenient to exclude a file type from the .ackrc file. However, file types defined with the `--type-set` option and file types with multiple filters cannot be re-enabled from the command line.